### PR TITLE
chore: upgrade to Calcit 0.13

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@
 #/target
 
 .calcit-error.cirru
+.calcit/
 .compact-inc.cirru
 
 /dylibs/

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -92,9 +92,9 @@ dependencies = [
 
 [[package]]
 name = "cirru_edn"
-version = "0.7.9"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d054d1542ed06c390236ac86d7f318c0149f531978386cb6de74df47eda32f21"
+checksum = "7f9a574a5164698fdd0881368444c47fad4b3188f82898386b9f28b83d9626d7"
 dependencies = [
  "cirru_parser",
  "cjk",
@@ -104,9 +104,9 @@ dependencies = [
 
 [[package]]
 name = "cirru_parser"
-version = "0.2.14"
+version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3eb8163842a864d207664d4aaaa11dd767414ad1d1c1da4cb20e74fbe8a22fe"
+checksum = "91044eb215dc0a2a75af6d3955f0074a4e7024ed4608a3be812024a950bb4e73"
 dependencies = [
  "serde",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,8 +17,8 @@ crate-type = ["dylib"] # Creates dynamic lib
 serde = { version = "1.0.185", features = ["derive"] }
 serde_json = "1.0.149"
 chrono = "0.4.44"
-cirru_edn = "0.7.9"
-cirru_parser = "0.2.8"
+cirru_edn = "0.8.0"
+cirru_parser = "=0.2.15"
 nanoid = "0.4.0"
 rand = "0.8.5"
 ctrlc = "3.5.2"

--- a/calcit.cirru
+++ b/calcit.cirru
@@ -1,53 +1,63 @@
 
-{} (:about "|Machine-generated snapshot. Do not edit directly — changes will be overwritten. Use `cr query` to inspect and `cr edit`/`cr tree` to modify. Run `cr docs agents --full` first. Manual edits must follow format and schema conventions, then run `cr edit format`.") (:package |calcit.std)
-  :configs $ {} (:init-fn |calcit.std.test/main!) (:reload-fn |calcit.std.test/reload!) (:version |0.2.13)
-    :modules $ []
+{} (:about "|Machine-generated snapshot. Do not edit directly — changes will be overwritten. Use `cr query` to inspect and `cr edit`/`cr tree` to modify. Run `cr docs agents --full` first. Manual edits must follow format and schema conventions, then run `cr edit format`.") (:package |calcit.std) (:version |0.2.13)
   :entries $ {}
-    :stream-process $ {} (:init-fn |calcit.std.test.process/main!) (:reload-fn |calcit.std.test.process/main!) (:version |0.2.13)
+    :default $ {} (:description |) (:init-fn 'calcit.std.test/main!) (:mode :native) (:reload-fn 'calcit.std.test/reload!)
+      :modules $ []
+      :type-slots $ {}
+    :stream-process $ {} (:description |) (:init-fn 'calcit.std.test.process/main!) (:mode :native) (:reload-fn 'calcit.std.test.process/main!)
+      :modules $ []
+      :type-slots $ {}
   :files $ {}
-    |calcit.std.date $ %{} :FileEntry
+    |calcit.std.date $ %{} 'FileEntry
       :defs $ {}
-        |Date $ %{} :CodeEntry (:doc "|Date record type wrapping timestamps. Provides static methods: :now (current time), :parse (parse string), :timestamp (get timestamp), :add (add duration), :format (format output).") (:schema :dynamic)
+        |Date $ %{} 'CodeEntry (:doc "|Date record type wrapping timestamps. Provides static methods: :now (current time), :parse (parse string), :timestamp (get timestamp), :add (add duration), :format (format output).")
           :code $ quote
             def Date $ impl-traits Date0 DateImpl
           :examples $ []
-        |Date0 $ %{} :CodeEntry (:doc |) (:schema :dynamic)
+          :schema $ :: 'Dynamic
+        |Date0 $ %{} 'CodeEntry (:doc |)
           :code $ quote
-            defstruct Date0 $ :date :dynamic
+            defstruct Date0 $ :date 'Dynamic
           :examples $ []
-        |DateImpl $ %{} :CodeEntry (:doc |) (:schema :dynamic)
+          :schema $ :: 'Dynamic
+        |DateImpl $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defimpl DateImpl DateTrait
               .format $ fn (self & args)
-                format-time self $ first args
+                format-time self $ option:unwrap-or (first args) nil
               .add $ fn (self n k) (add-duration self n k)
               .timestamp $ fn (self) (get-timestamp self)
               .extract $ fn (self) (extract-time self)
           :examples $ []
-        |DateTrait $ %{} :CodeEntry (:doc |) (:schema :dynamic)
+          :schema $ :: 'Dynamic
+        |DateTrait $ %{} 'CodeEntry (:doc |)
           :code $ quote
             deftrait DateTrait (.format :fn) (.add :fn) (.timestamp :fn) (.extract :fn)
           :examples $ []
-        |add-duration $ %{} :CodeEntry (:doc "|Add duration to Date object. Args: date object, numeric value, time unit (:days, :hours, :minutes, :seconds, etc). Example: (add-duration (get-time!) 7 :days)") (:schema :dynamic)
+          :schema $ :: 'Dynamic
+        |add-duration $ %{} 'CodeEntry (:doc "|Add duration to Date object. Args: date object, numeric value, time unit (:days, :hours, :minutes, :seconds, etc). Example: (add-duration (get-time!) 7 :days)")
           :code $ quote
             defn add-duration (date n k)
               %{} Date $ :date
                 &call-dylib-edn (get-dylib-path |/dylibs/libcalcit_std) |add_duration (:date date) n k
           :examples $ []
             quote $ add-duration (get-time!) 7 :days
-        |extract-time $ %{} :CodeEntry (:doc "|Extract time components from Date object. Returns a Map with :year, :month, :day, :hour, :minute, :second fields. Example: (extract-time (get-time!))") (:schema :dynamic)
+          :schema $ :: 'Dynamic
+        |extract-time $ %{} 'CodeEntry (:doc "|Extract time components from Date object. Returns a Map with :year, :month, :day, :hour, :minute, :second fields. Example: (extract-time (get-time!))")
           :code $ quote
             defn extract-time (x)
               &call-dylib-edn (get-dylib-path |/dylibs/libcalcit_std) |extract_time $ :date x
           :examples $ []
             quote $ extract-time (get-time!)
-        |format-time $ %{} :CodeEntry (:doc "|Format Date object to string. Optional second parameter specifies format (default ISO format). Example: (format-time (get-time!) \"|%Y-%m-%d\")") (:schema :dynamic)
+          :schema $ :: 'Dynamic
+        |format-time $ %{} 'CodeEntry (:doc "|Format Date object to string. Optional second parameter specifies format (default ISO format). Example: (format-time (get-time!) \"|%Y-%m-%d\")")
           :code $ quote
             defn format-time (time ? format)
               &call-dylib-edn (get-dylib-path |/dylibs/libcalcit_std) |format_time (:date time) format
           :examples $ []
             quote $ format-time (get-time!) |%Y-%m-%d
-        |from-ymd $ %{} :CodeEntry (:doc "|Create Date object from year, month, day. Args: year, month (1-12), day (1-31). Example: (from-ymd 2024 1 15)") (:schema :dynamic)
+          :schema $ :: 'Dynamic
+        |from-ymd $ %{} 'CodeEntry (:doc "|Create Date object from year, month, day. Args: year, month (1-12), day (1-31). Example: (from-ymd 2024 1 15)")
           :code $ quote
             defn from-ymd (y m d)
               tag-match
@@ -60,7 +70,8 @@
                 _ $ raise |unreachable!
           :examples $ []
             quote $ from-ymd 2024 1 15
-        |from-ywd $ %{} :CodeEntry (:doc "|Create Date object from year, week, day. Args: year, week (1-53), day (1-7, 1=Monday). Example: (from-ywd 2024 1 1)") (:schema :dynamic)
+          :schema $ :: 'Dynamic
+        |from-ywd $ %{} 'CodeEntry (:doc "|Create Date object from year, week, day. Args: year, week (1-53), day (1-7, 1=Monday). Example: (from-ywd 2024 1 1)")
           :code $ quote
             defn from-ywd (y w d)
               tag-match
@@ -73,130 +84,148 @@
                 _ $ raise |unreachable!
           :examples $ []
             quote $ from-ywd 2024 1 1
-        |get-time! $ %{} :CodeEntry (:doc "|Get current system time as a Date object. Example: (get-time!)") (:schema :dynamic)
+          :schema $ :: 'Dynamic
+        |get-time! $ %{} 'CodeEntry (:doc "|Get current system time as a Date object. Example: (get-time!)")
           :code $ quote
             defn get-time! () $ %{} Date
               :date $ &call-dylib-edn (get-dylib-path |/dylibs/libcalcit_std) |now_bang
           :examples $ []
             quote $ get-time!
-        |get-timestamp $ %{} :CodeEntry (:doc "|Get timestamp (milliseconds) from Date object. Example: (get-timestamp (get-time!))") (:schema :dynamic)
+          :schema $ :: 'Dynamic
+        |get-timestamp $ %{} 'CodeEntry (:doc "|Get timestamp (milliseconds) from Date object. Example: (get-timestamp (get-time!))")
           :code $ quote
             defn get-timestamp (date)
               &call-dylib-edn (get-dylib-path |/dylibs/libcalcit_std) |get_timestamp $ :date date
           :examples $ []
             quote $ get-timestamp (get-time!)
-        |parse-time $ %{} :CodeEntry (:doc "|Parse time string to Date object. Args: time string, format string (e.g. %Y-%m-%d %H:%M:%S %z). Example: (parse-time \"|2024-01-01 12:00:00 +00:00\" \"|%Y-%m-%d %H:%M:%S %z\")") (:schema :dynamic)
+          :schema $ :: 'Dynamic
+        |parse-time $ %{} 'CodeEntry (:doc "|Parse time string to Date object. Args: time string, format string (e.g. %Y-%m-%d %H:%M:%S %z). Example: (parse-time \"|2024-01-01 12:00:00 +00:00\" \"|%Y-%m-%d %H:%M:%S %z\")")
           :code $ quote
             defn parse-time (time format)
               %{} Date $ :date
                 &call-dylib-edn (get-dylib-path |/dylibs/libcalcit_std) |parse_time time format
           :examples $ []
             quote $ parse-time "|2024-01-01 12:00:00 +00:00" "|%Y-%m-%d %H:%M:%S %z"
-      :ns $ %{} :NsEntry (:doc |)
+          :schema $ :: 'Dynamic
+      :ns $ %{} 'NsEntry (:doc |)
         :code $ quote
           ns calcit.std.date $ :require
             calcit.std.$meta :refer $ calcit-dirname
             calcit.std.util :refer $ get-dylib-path
-    |calcit.std.fs $ %{} :FileEntry
+    |calcit.std.fs $ %{} 'FileEntry
       :defs $ {}
-        |append-file! $ %{} :CodeEntry (:doc "|Append content to end of file. Args: file path, content string. Example: (append-file! \"log.txt\" \"New log entry\")") (:schema :dynamic)
+        |append-file! $ %{} 'CodeEntry (:doc "|Append content to end of file. Args: file path, content string. Example: (append-file! \"log.txt\" \"New log entry\")")
           :code $ quote
             defn append-file! (name content)
               &call-dylib-edn (get-dylib-path |/dylibs/libcalcit_std) |append_file name content
           :examples $ []
             quote $ append-file! |log.txt | "New log entry"
-        |check-write-file! $ %{} :CodeEntry (:doc "|Check if file exists, write content if not exists. Args: file path, content string.") (:schema :dynamic)
+          :schema $ :: 'Dynamic
+        |check-write-file! $ %{} 'CodeEntry (:doc "|Check if file exists, write content if not exists. Args: file path, content string.")
           :code $ quote
             defn check-write-file! (name content)
               &call-dylib-edn (get-dylib-path |/dylibs/libcalcit_std) |check_write_file name content
           :examples $ []
-        |create-dir! $ %{} :CodeEntry (:doc "|Create a directory at the given path. Fails if parent directory does not exist. Example: (create-dir! \"new-folder\")") (:schema :dynamic)
+          :schema $ :: 'Dynamic
+        |create-dir! $ %{} 'CodeEntry (:doc "|Create a directory at the given path. Fails if parent directory does not exist. Example: (create-dir! \"new-folder\")")
           :code $ quote
             defn create-dir! (name)
               &call-dylib-edn (get-dylib-path |/dylibs/libcalcit_std) |create_dir name
           :examples $ []
             quote $ create-dir! |new-folder
-        |create-dir-all! $ %{} :CodeEntry (:doc "|Create a directory and all necessary parent directories. Example: (create-dir-all! \"path/to/nested/dir\")") (:schema :dynamic)
+          :schema $ :: 'Dynamic
+        |create-dir-all! $ %{} 'CodeEntry (:doc "|Create a directory and all necessary parent directories. Example: (create-dir-all! \"path/to/nested/dir\")")
           :code $ quote
             defn create-dir-all! (name)
               &call-dylib-edn (get-dylib-path |/dylibs/libcalcit_std) |create_dir_all name
           :examples $ []
             quote $ create-dir-all! |path/to/nested/dir
-        |glob! $ %{} :CodeEntry (:doc "|Find files matching the glob pattern. Returns a list of matching file paths. Example: (glob! \"src/*.rs\")") (:schema :dynamic)
+          :schema $ :: 'Dynamic
+        |glob! $ %{} 'CodeEntry (:doc "|Find files matching the glob pattern. Returns a list of matching file paths. Example: (glob! \"src/*.rs\")")
           :code $ quote
             defn glob! (name)
               &call-dylib-edn (get-dylib-path |/dylibs/libcalcit_std) |glob_call name
           :examples $ []
             quote $ glob! | src/**/*.rs
-        |path-exists? $ %{} :CodeEntry (:doc "|Check if a file or directory exists at the given path. Returns boolean. Example: (path-exists? \"README.md\")") (:schema :dynamic)
+          :schema $ :: 'Dynamic
+        |path-exists? $ %{} 'CodeEntry (:doc "|Check if a file or directory exists at the given path. Returns boolean. Example: (path-exists? \"README.md\")")
           :code $ quote
             defn path-exists? (name)
               &call-dylib-edn (get-dylib-path |/dylibs/libcalcit_std) |path_exists name
           :examples $ []
             quote $ path-exists? |file.txt
-        |read-dir! $ %{} :CodeEntry (:doc "|Read directory contents and return a list of file/directory names. Example: (read-dir! \"src\")") (:schema :dynamic)
+          :schema $ :: 'Dynamic
+        |read-dir! $ %{} 'CodeEntry (:doc "|Read directory contents and return a list of file/directory names. Example: (read-dir! \"src\")")
           :code $ quote
             defn read-dir! (name)
               &call-dylib-edn (get-dylib-path |/dylibs/libcalcit_std) |read_dir name
           :examples $ []
             quote $ read-dir! |src
-        |read-file! $ %{} :CodeEntry (:doc "|Read entire file content as a string. Args: file path. Example: (read-file! \"README.md\")") (:schema :dynamic)
+          :schema $ :: 'Dynamic
+        |read-file! $ %{} 'CodeEntry (:doc "|Read entire file content as a string. Args: file path. Example: (read-file! \"README.md\")")
           :code $ quote
             defn read-file! (name)
               &call-dylib-edn (get-dylib-path |/dylibs/libcalcit_std) |read_file name
           :examples $ []
             quote $ read-file! |example.txt
-        |read-file-by-line! $ %{} :CodeEntry (:doc "|Read file line by line and call the callback function for each line. Args: file path, callback function. Example: (read-file-by-line! \"file.txt\" (fn (line) (println line)))") (:schema :dynamic)
+          :schema $ :: 'Dynamic
+        |read-file-by-line! $ %{} 'CodeEntry (:doc "|Read file line by line and call the callback function for each line. Args: file path, callback function. Example: (read-file-by-line! \"file.txt\" (fn (line) (println line)))")
           :code $ quote
             defn read-file-by-line! (name cb)
               &blocking-dylib-edn-fn (get-dylib-path |/dylibs/libcalcit_std) |read_file_by_line name cb
           :examples $ []
             quote $ read-file-by-line! |file.txt
               fn (line) (println line)
-        |rename! $ %{} :CodeEntry (:doc "|Rename or move a file/directory. Args: source path, destination path. Example: (rename! \"old.txt\" \"new.txt\")") (:schema :dynamic)
+          :schema $ :: 'Dynamic
+        |rename! $ %{} 'CodeEntry (:doc "|Rename or move a file/directory. Args: source path, destination path. Example: (rename! \"old.txt\" \"new.txt\")")
           :code $ quote
             defn rename! (from to)
               &call-dylib-edn (get-dylib-path |/dylibs/libcalcit_std) |rename_path from to
           :examples $ []
             quote $ rename! |old.txt |new.txt
-        |walk-dir! $ %{} :CodeEntry (:doc "|Recursively walk through directory and return all file paths. Example: (walk-dir! \"target\")") (:schema :dynamic)
+          :schema $ :: 'Dynamic
+        |walk-dir! $ %{} 'CodeEntry (:doc "|Recursively walk through directory and return all file paths. Example: (walk-dir! \"target\")")
           :code $ quote
             defn walk-dir! (name)
               &call-dylib-edn (get-dylib-path |/dylibs/libcalcit_std) |walk_dir name
           :examples $ []
-        |write-file! $ %{} :CodeEntry (:doc "|Write content to file (overwrite). Args: file path, content string. Example: (write-file! \"output.txt\" \"Hello, World!\")") (:schema :dynamic)
+          :schema $ :: 'Dynamic
+        |write-file! $ %{} 'CodeEntry (:doc "|Write content to file (overwrite). Args: file path, content string. Example: (write-file! \"output.txt\" \"Hello, World!\")")
           :code $ quote
             defn write-file! (name content)
               &call-dylib-edn (get-dylib-path |/dylibs/libcalcit_std) |write_file name content
           :examples $ []
             quote $ write-file! |output.txt | "Hello, World!"
-      :ns $ %{} :NsEntry (:doc |)
+          :schema $ :: 'Dynamic
+      :ns $ %{} 'NsEntry (:doc |)
         :code $ quote
           ns calcit.std.fs $ :require
             calcit.std.$meta :refer $ calcit-dirname
             calcit.std.util :refer $ get-dylib-path
-    |calcit.std.hash $ %{} :FileEntry
+    |calcit.std.hash $ %{} 'FileEntry
       :defs $ {}
-        |md5 $ %{} :CodeEntry (:doc "|Calculate MD5 hash of a string. Returns 32-character hexadecimal string. Example: (md5 \"hello\")") (:schema :dynamic)
+        |md5 $ %{} 'CodeEntry (:doc "|Calculate MD5 hash of a string. Returns 32-character hexadecimal string. Example: (md5 \"hello\")")
           :code $ quote
             defn md5 (s)
               &call-dylib-edn (get-dylib-path |/dylibs/libcalcit_std) |md5 s
           :examples $ []
             quote $ md5 |hello
-      :ns $ %{} :NsEntry (:doc |)
+          :schema $ :: 'Dynamic
+      :ns $ %{} 'NsEntry (:doc |)
         :code $ quote
           ns calcit.std.hash $ :require
             calcit.std.$meta :refer $ calcit-dirname
             calcit.std.util :refer $ get-dylib-path
-    |calcit.std.json $ %{} :FileEntry
+    |calcit.std.json $ %{} 'FileEntry
       :defs $ {}
-        |parse-json $ %{} :CodeEntry (:doc "|Parse JSON string to Calcit data structures. String keys remain as strings, keyword keys become keywords. Example: (parse-json \"|{\\\"a\\\": [1, 2], \\\":b\\\": 3}\")") (:schema :dynamic)
+        |parse-json $ %{} 'CodeEntry (:doc "|Parse JSON string to Calcit data structures. String keys remain as strings, keyword keys become keywords. Example: (parse-json \"|{\\\"a\\\": [1, 2], \\\":b\\\": 3}\")")
           :code $ quote
             defn parse-json (s)
               &call-dylib-edn (get-dylib-path |/dylibs/libcalcit_std) |parse_json s
           :examples $ []
             quote $ parse-json "|{\"a\": [1, 2], \":b\": 3}"
-        |stringify-json $ %{} :CodeEntry (:doc "|Serialize Calcit data structures to JSON string. Second parameter colon? when true converts keywords to strings with colon prefix. Example: (stringify-json {:a 1} true)") (:schema :dynamic)
+          :schema $ :: 'Dynamic
+        |stringify-json $ %{} 'CodeEntry (:doc "|Serialize Calcit data structures to JSON string. Second parameter colon? when true converts keywords to strings with colon prefix. Example: (stringify-json {:a 1} true)")
           :code $ quote
             defn stringify-json (data ? colon?)
               &call-dylib-edn (get-dylib-path |/dylibs/libcalcit_std) |stringify_json data colon?
@@ -205,136 +234,154 @@
             quote $ stringify-json
               {} (:a 1) (:b 2)
               , true
-      :ns $ %{} :NsEntry (:doc |)
+          :schema $ :: 'Dynamic
+      :ns $ %{} 'NsEntry (:doc |)
         :code $ quote
           ns calcit.std.json $ :require
             calcit.std.$meta :refer $ calcit-dirname
             calcit.std.util :refer $ get-dylib-path
-    |calcit.std.path $ %{} :FileEntry
+    |calcit.std.path $ %{} 'FileEntry
       :defs $ {}
-        |join-path $ %{} :CodeEntry (:doc "|Join multiple path segments into a complete path, handling separators automatically. Example: (join-path \"/home\" \"user\" \"documents\" \"file.txt\")") (:schema :dynamic)
+        |join-path $ %{} 'CodeEntry (:doc "|Join multiple path segments into a complete path, handling separators automatically. Example: (join-path \"/home\" \"user\" \"documents\" \"file.txt\")")
           :code $ quote
             defn join-path (& xs)
               &call-dylib-edn (get-dylib-path |/dylibs/libcalcit_std) |join_path & xs
           :examples $ []
             quote $ join-path |/home |user |documents |file.txt
-        |path-basename $ %{} :CodeEntry (:doc "|Get the filename part of a path (the last path component). Example: (path-basename \"/home/user/file.txt\")") (:schema :dynamic)
+          :schema $ :: 'Dynamic
+        |path-basename $ %{} 'CodeEntry (:doc "|Get the filename part of a path (the last path component). Example: (path-basename \"/home/user/file.txt\")")
           :code $ quote
             defn path-basename (x)
               &call-dylib-edn (get-dylib-path |/dylibs/libcalcit_std) |path_basename x
           :examples $ []
             quote $ path-basename |/home/user/file.txt
-        |path-dirname $ %{} :CodeEntry (:doc "|Get the directory part of a path (excluding the last component). Example: (path-dirname \"/home/user/file.txt\")") (:schema :dynamic)
+          :schema $ :: 'Dynamic
+        |path-dirname $ %{} 'CodeEntry (:doc "|Get the directory part of a path (excluding the last component). Example: (path-dirname \"/home/user/file.txt\")")
           :code $ quote
             defn path-dirname (x)
               &call-dylib-edn (get-dylib-path |/dylibs/libcalcit_std) |path_dirname x
           :examples $ []
             quote $ path-dirname |/home/user/file.txt
-      :ns $ %{} :NsEntry (:doc |)
+          :schema $ :: 'Dynamic
+      :ns $ %{} 'NsEntry (:doc |)
         :code $ quote
           ns calcit.std.path $ :require
             calcit.std.$meta :refer $ calcit-dirname
             calcit.std.util :refer $ get-dylib-path
-    |calcit.std.process $ %{} :FileEntry
+    |calcit.std.process $ %{} 'FileEntry
       :defs $ {}
-        |ProcessOutput $ %{} :CodeEntry (:doc "|A streamed process output event.") (:schema :dynamic)
+        |ProcessOutput $ %{} 'CodeEntry (:doc "|A streamed process output event.")
           :code $ quote
-            defenum ProcessOutput (:stdout :string) (:stderr :string)
+            defenum ProcessOutput (:stdout 'String) (:stderr 'String)
           :examples $ []
-        |stream! $ %{} :CodeEntry (:doc "|Start a process and stream tagged stdout/stderr events to callback. Runs asynchronously.") (:schema :dynamic)
-          :code $ quote
-            defn stream! (command f ? dir)
-              assert "|command in list" $ and (list? command) (every? command string?)
-              &call-dylib-edn-fn (get-dylib-path |/dylibs/libcalcit_std) |stream_command (either dir |./) command f
-          :examples $ []
-            quote $ stream! ([] |sh "|-c" "|printf 'out-1\\n'; sleep 0.2; printf 'err-1\\n' >&2; sleep 0.2; printf 'out-2\\n'; sleep 0.2; printf 'err-2\\n' >&2") $ fn (event)
-              println |received-ProcessOutput event
-        |execute! $ %{} :CodeEntry (:doc "|Execute a shell command. Args: command as list of strings, optional working directory. Returns output or error. Example: (execute! [] \"ls\" \"-la\")") (:schema :dynamic)
+          :schema $ :: 'Dynamic
+        |execute! $ %{} 'CodeEntry (:doc "|Execute a shell command. Args: command as list of strings, optional working directory. Returns output or error. Example: (execute! [] \"ls\" \"-la\")")
           :code $ quote
             defn execute! (command ? dir)
               assert "|command in list" $ and (list? command) (every? command string?)
               &call-dylib-edn (get-dylib-path |/dylibs/libcalcit_std) |execute_command (either dir |./) command
           :examples $ []
             quote $ execute! ([] |ls | -la)
-        |on-ctrl-c $ %{} :CodeEntry (:doc "|Register a callback function to handle Ctrl+C signal.") (:schema :dynamic)
+          :schema $ :: 'Dynamic
+        |on-ctrl-c $ %{} 'CodeEntry (:doc "|Register a callback function to handle Ctrl+C signal.")
           :code $ quote
             defn on-ctrl-c (f)
               &call-dylib-edn-fn (get-dylib-path |/dylibs/libcalcit_std) |on_ctrl_c f
           :examples $ []
             quote $ on-ctrl-c
               fn () $ println | Exiting...
-      :ns $ %{} :NsEntry (:doc |)
+          :schema $ :: 'Dynamic
+        |stream! $ %{} 'CodeEntry (:doc "|Start a process and stream tagged stdout/stderr events to callback. Runs asynchronously.")
+          :code $ quote
+            defn stream! (command f ? dir)
+              assert "|command in list" $ and (list? command) (every? command string?)
+              &call-dylib-edn-fn (get-dylib-path |/dylibs/libcalcit_std) |stream_command (either dir |./) command f
+          :examples $ []
+            quote $ stream! ([] |sh |-c "|printf 'out-1\\n'; sleep 0.2; printf 'err-1\\n' >&2; sleep 0.2; printf 'out-2\\n'; sleep 0.2; printf 'err-2\\n' >&2")
+              fn (event) (println |received-ProcessOutput event)
+          :schema $ :: 'Dynamic
+      :ns $ %{} 'NsEntry (:doc |)
         :code $ quote
           ns calcit.std.process $ :require
             calcit.std.$meta :refer $ calcit-dirname
             calcit.std.util :refer $ get-dylib-path
-    |calcit.std.rand $ %{} :FileEntry
+    |calcit.std.rand $ %{} 'FileEntry
       :defs $ {}
-        |nanoid! $ %{} :CodeEntry (:doc "|Generate nanoid string. Optional: size (default 21), chars (character set). Example: (nanoid! 9)") (:schema :dynamic)
+        |nanoid! $ %{} 'CodeEntry (:doc "|Generate nanoid string. Optional: size (default 21), chars (character set). Example: (nanoid! 9)")
           :code $ quote
             defn nanoid! (? size chars)
               &call-dylib-edn (get-dylib-path |/dylibs/libcalcit_std) |call_nanoid size chars
           :examples $ []
             quote $ nanoid!
             quote $ nanoid! 10
-        |rand $ %{} :CodeEntry (:doc "|Generate random float. No args: [0, 1), one arg: [0, n), two args: [from, to). Example: (rand 10 100)") (:schema :dynamic)
+          :schema $ :: 'Dynamic
+        |rand $ %{} 'CodeEntry (:doc "|Generate random float. No args: [0, 1), one arg: [0, n), two args: [from, to). Example: (rand 10 100)")
           :code $ quote
             defn rand (? from to)
               &call-dylib-edn (get-dylib-path |/dylibs/libcalcit_std) |rand from to
           :examples $ []
             quote $ rand
             quote $ rand 10 100
-        |rand-between $ %{} :CodeEntry (:doc "|Generate random float between from and to.") (:schema :dynamic)
+          :schema $ :: 'Dynamic
+        |rand-between $ %{} 'CodeEntry (:doc "|Generate random float between from and to.")
           :code $ quote
             defn rand-between (x y)
               &+ x $ rand (&- y x)
           :examples $ []
             quote $ rand-between 10 20
-        |rand-hex-color! $ %{} :CodeEntry (:doc "|Generate random hexadecimal color string in format #rrggbb. Example: (rand-hex-color!)") (:schema :dynamic)
+          :schema $ :: 'Dynamic
+        |rand-hex-color! $ %{} 'CodeEntry (:doc "|Generate random hexadecimal color string in format #rrggbb. Example: (rand-hex-color!)")
           :code $ quote
             defn rand-hex-color! () $ &call-dylib-edn (get-dylib-path |/dylibs/libcalcit_std) |rand_hex_color
           :examples $ []
             quote $ rand-hex-color!
-        |rand-int $ %{} :CodeEntry (:doc "|Generate random integer. No args: large range, one arg: [0, n), two args: [from, to). Example: (rand-int 100)") (:schema :dynamic)
+          :schema $ :: 'Dynamic
+        |rand-int $ %{} 'CodeEntry (:doc "|Generate random integer. No args: large range, one arg: [0, n), two args: [from, to). Example: (rand-int 100)")
           :code $ quote
             defn rand-int (? from to)
               &call-dylib-edn (get-dylib-path |/dylibs/libcalcit_std) |rand_int from to
           :examples $ []
             quote $ rand-int 100
-        |rand-nth $ %{} :CodeEntry (:doc "|Randomly select one element from a list.") (:schema :dynamic)
+          :schema $ :: 'Dynamic
+        |rand-nth $ %{} 'CodeEntry (:doc "|Randomly select one element from a list.")
           :code $ quote
             defn rand-nth (xs)
               if (&list:empty? xs) nil $ get xs
                 rand-int $ &- (&list:count xs) 1
           :examples $ []
             quote $ rand-nth ([] 1 2 3 4 5)
-        |rand-shift $ %{} :CodeEntry (:doc "|Generate random float within center ± shift range.") (:schema :dynamic)
+          :schema $ :: 'Dynamic
+        |rand-shift $ %{} 'CodeEntry (:doc "|Generate random float within center ± shift range.")
           :code $ quote
             defn rand-shift (x y)
               &+ (&- x y)
                 rand $ &* 2 y
           :examples $ []
             quote $ rand-shift 10 2
-      :ns $ %{} :NsEntry (:doc |)
+          :schema $ :: 'Dynamic
+      :ns $ %{} 'NsEntry (:doc |)
         :code $ quote
           ns calcit.std.rand $ :require
             calcit.std.$meta :refer $ calcit-dirname
             calcit.std.util :refer $ get-dylib-path
-    |calcit.std.test $ %{} :FileEntry
+    |calcit.std.test $ %{} 'FileEntry
       :defs $ {}
-        |main! $ %{} :CodeEntry (:doc |) (:schema :dynamic)
+        |main! $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defn main! () (run-tests) (try-demos)
           :examples $ []
-        |reload! $ %{} :CodeEntry (:doc |) (:schema :dynamic)
+          :schema $ :: 'Dynamic
+        |reload! $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defn reload! () (run-tests) (println "|reload not handled yet")
           :examples $ []
-        |run-tests $ %{} :CodeEntry (:doc |) (:schema :dynamic)
+          :schema $ :: 'Dynamic
+        |run-tests $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defn run-tests () (fs/main!) (json/main!) (date/main!) (random/main!) (test-path)
           :examples $ []
-        |test-path $ %{} :CodeEntry (:doc |) (:schema :dynamic)
+          :schema $ :: 'Dynamic
+        |test-path $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defn test-path ()
               assert= |a/b $ join-path |a |b
@@ -343,33 +390,37 @@
               assert= |a/b $ path-dirname |a/b/c
               assert= |c $ path-basename |a/b/c
           :examples $ []
-        |try-ctrlc! $ %{} :CodeEntry (:doc |) (:schema :dynamic)
+          :schema $ :: 'Dynamic
+        |try-ctrlc! $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defn try-ctrlc! () $ on-ctrl-c
               fn () $ println "|TODO handler..."
           :examples $ []
-        |try-demos $ %{} :CodeEntry (:doc |) (:schema :dynamic)
+          :schema $ :: 'Dynamic
+        |try-demos $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defn try-demos ()
               println $ md5 |
               println $ md5 |5
           :examples $ []
-        |try-time! $ %{} :CodeEntry (:doc |) (:schema :dynamic)
+          :schema $ :: 'Dynamic
+        |try-time! $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defn try-time! ()
               set-timeout 4000 $ fn () (println |doing)
               set-interval 2000 $ fn () (println "|DO Do Do")
           :examples $ []
-      :ns $ %{} :NsEntry (:doc |)
+          :schema $ :: 'Dynamic
+      :ns $ %{} 'NsEntry (:doc |)
         :code $ quote
           ns calcit.std.test $ :require (calcit.std.test.fs :as fs) (calcit.std.test.date :as date) (calcit.std.test.json :as json) (calcit.std.test.rand :as random)
             calcit.std.process :refer $ on-ctrl-c
             calcit.std.time :refer $ set-timeout set-interval
             calcit.std.hash :refer $ md5
             calcit.std.path :refer $ join-path path-dirname path-basename
-    |calcit.std.test.date $ %{} :FileEntry
+    |calcit.std.test.date $ %{} 'FileEntry
       :defs $ {}
-        |main! $ %{} :CodeEntry (:doc |) (:schema :dynamic)
+        |main! $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defn main! () (println &newline "|%%%% test date")
               println "|GET TIME" $ get-time!
@@ -391,17 +442,19 @@
                   ; assert= "|2021-11-10 16-00" $ -> d (.add -8 :hours) (format-time "|%Y-%m-%d %H-%M")
               println $ -> (get-time!) (.add 1 :hours) (.add 2 :minutes) (.format "|%Y-%m-%d %H-%M")
           :examples $ []
-        |reload! $ %{} :CodeEntry (:doc |) (:schema :dynamic)
+          :schema $ :: 'Dynamic
+        |reload! $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defn reload! () $ main!
           :examples $ []
-      :ns $ %{} :NsEntry (:doc |)
+          :schema $ :: 'Dynamic
+      :ns $ %{} 'NsEntry (:doc |)
         :code $ quote
           ns calcit.std.test.date $ :require
             calcit.std.date :refer $ parse-time format-time get-time! extract-time from-ymd from-ywd add-duration Date get-timestamp
-    |calcit.std.test.fs $ %{} :FileEntry
+    |calcit.std.test.fs $ %{} 'FileEntry
       :defs $ {}
-        |main! $ %{} :CodeEntry (:doc |) (:schema :dynamic)
+        |main! $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defn main! () (println "|%%%% test for fs") (println calcit-filename calcit-dirname)
               println $ >
@@ -422,28 +475,16 @@
               check-write-file! |target/dir8/dir9/file.text |TODO
               append-file! |target/dir8/dir9/file.text $ str &newline "|NEWLINE TODO"
           :examples $ []
-      :ns $ %{} :NsEntry (:doc |)
+          :schema $ :: 'Dynamic
+      :ns $ %{} 'NsEntry (:doc |)
         :code $ quote
           ns calcit.std.test.fs $ :require
             calcit.std.$meta :refer $ calcit-filename calcit-dirname
             calcit.std.fs :refer $ read-file! append-file! write-file! path-exists? read-dir! create-dir! create-dir-all! rename! check-write-file! walk-dir! glob! read-file-by-line!
             calcit.std.process :refer $ execute!
-    |calcit.std.test.process $ %{} :FileEntry
+    |calcit.std.test.json $ %{} 'FileEntry
       :defs $ {}
-        |main! $ %{} :CodeEntry (:doc "|Verify streamed stdout/stderr events from a child process.") (:schema :dynamic)
-          :code $ quote
-            defn main! ()
-              println |starting-streamed-process
-              stream! ([] |sh "|-c" "|printf 'out-1\\n'; sleep 0.2; printf 'err-1\\n' >&2; sleep 0.2; printf 'out-2\\n'; sleep 0.2; printf 'err-2\\n' >&2") $ fn (event)
-                println |received-ProcessOutput event
-          :examples $ []
-      :ns $ %{} :NsEntry (:doc |)
-        :code $ quote
-          ns calcit.std.test.process $ :require
-            calcit.std.process :refer $ stream! ProcessOutput
-    |calcit.std.test.json $ %{} :FileEntry
-      :defs $ {}
-        |main! $ %{} :CodeEntry (:doc |) (:schema :dynamic)
+        |main! $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defn main! () (println "|%%%% test for json")
               println $ stringify-json ([] 1 2 3 :a)
@@ -461,7 +502,8 @@
                   parse-json $ stringify-json data
                   {} (|a 1) (|b 2) (|c |k)
           :examples $ []
-        |slurp-cirru-edn $ %{} :CodeEntry (:doc |) (:schema :dynamic)
+          :schema $ :: 'Dynamic
+        |slurp-cirru-edn $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defmacro slurp-cirru-edn (file)
               with-cpu-time $ stringify-json
@@ -469,22 +511,36 @@
                   parse-cirru $ read-file file
                 , true
           :examples $ []
-        |try-large-json $ %{} :CodeEntry (:doc |) (:schema :dynamic)
+          :schema $ :: 'Dynamic
+        |try-large-json $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defn try-large-json () $ slurp-cirru-edn |/Users/chen/repo/calcit-lang/apis/docs/apis.cirru
           :examples $ []
-      :ns $ %{} :NsEntry (:doc |)
+          :schema $ :: 'Dynamic
+      :ns $ %{} 'NsEntry (:doc |)
         :code $ quote
           ns calcit.std.test.json $ :require
             calcit.std.json :refer $ parse-json stringify-json
-    |calcit.std.test.rand $ %{} :FileEntry
+    |calcit.std.test.process $ %{} 'FileEntry
       :defs $ {}
-        |main! $ %{} :CodeEntry (:doc |) (:schema :dynamic)
+        |main! $ %{} 'CodeEntry (:doc "|Verify streamed stdout/stderr events from a child process.")
+          :code $ quote
+            defn main! () (println |starting-streamed-process)
+              stream! ([] |sh |-c "|printf 'out-1\\n'; sleep 0.2; printf 'err-1\\n' >&2; sleep 0.2; printf 'out-2\\n'; sleep 0.2; printf 'err-2\\n' >&2")
+                fn (event) (println |received-ProcessOutput event)
+          :examples $ []
+          :schema $ :: 'Dynamic
+      :ns $ %{} 'NsEntry (:doc |)
+        :code $ quote
+          ns calcit.std.test.process $ :require
+            calcit.std.process :refer $ stream! ProcessOutput
+    |calcit.std.test.rand $ %{} 'FileEntry
+      :defs $ {}
+        |main! $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defn main! () (println "|%%%%%% test random")
-              assert-detect identity $ <= 0
-                index-of (range 10)
-                  rand-nth $ range 10
+              assert-detect identity $ option:some?
+                rand-nth $ range 10
               assert= nil $ rand-nth ([])
               assert= nil $ ;nil anything
               assert-detect identity $ <= 0 (rand) 100
@@ -504,48 +560,54 @@
               assert= |aaaaa $ nanoid! 5 |a
               println $ rand-hex-color!
           :examples $ []
-      :ns $ %{} :NsEntry (:doc |)
+          :schema $ :: 'Dynamic
+      :ns $ %{} 'NsEntry (:doc |)
         :code $ quote
           ns calcit.std.test.rand $ :require
             calcit.std.rand :refer $ rand rand-int rand-shift rand-nth rand-between nanoid! rand-hex-color!
-    |calcit.std.time $ %{} :FileEntry
+    |calcit.std.time $ %{} 'FileEntry
       :defs $ {}
-        |set-interval $ %{} :CodeEntry (:doc "|Execute function repeatedly at intervals. Args: interval in milliseconds, function to repeat. Example: (set-interval 1000 (fn () (println \"tick\")))") (:schema :dynamic)
+        |set-interval $ %{} 'CodeEntry (:doc "|Execute function repeatedly at intervals. Args: interval in milliseconds, function to repeat. Example: (set-interval 1000 (fn () (println \"tick\")))")
           :code $ quote
             defn set-interval (t cb)
               &call-dylib-edn-fn (get-dylib-path |/dylibs/libcalcit_std) |set_interval t cb
           :examples $ []
             quote $ set-interval 1000
               fn () $ println |tick
-        |set-timeout $ %{} :CodeEntry (:doc "|Execute function after delay. Args: delay in milliseconds, function to execute. Example: (set-timeout 1000 (fn () (println \"timeout\")))") (:schema :dynamic)
+          :schema $ :: 'Dynamic
+        |set-timeout $ %{} 'CodeEntry (:doc "|Execute function after delay. Args: delay in milliseconds, function to execute. Example: (set-timeout 1000 (fn () (println \"timeout\")))")
           :code $ quote
             defn set-timeout (t cb)
               &call-dylib-edn-fn (get-dylib-path |/dylibs/libcalcit_std) |set_timeout t cb
           :examples $ []
             quote $ set-timeout 1000
               fn () $ println |timeout
-      :ns $ %{} :NsEntry (:doc |)
+          :schema $ :: 'Dynamic
+      :ns $ %{} 'NsEntry (:doc |)
         :code $ quote
           ns calcit.std.time $ :require
             calcit.std.$meta :refer $ calcit-dirname
             calcit.std.util :refer $ get-dylib-path
-    |calcit.std.util $ %{} :FileEntry
+    |calcit.std.util $ %{} 'FileEntry
       :defs $ {}
-        |get-dylib-ext $ %{} :CodeEntry (:doc |) (:schema :dynamic)
+        |get-dylib-ext $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defmacro get-dylib-ext () $ case-default (&get-os) |.so (:macos |.dylib) (:windows |.dll)
           :examples $ []
-        |get-dylib-path $ %{} :CodeEntry (:doc |) (:schema :dynamic)
+          :schema $ :: 'Dynamic
+        |get-dylib-path $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defn get-dylib-path (p)
               str (or-current-path calcit-dirname) p $ get-dylib-ext
           :examples $ []
-        |or-current-path $ %{} :CodeEntry (:doc |) (:schema :dynamic)
+          :schema $ :: 'Dynamic
+        |or-current-path $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defn or-current-path (p)
               if (blank? p) |. p
           :examples $ []
-      :ns $ %{} :NsEntry (:doc |)
+          :schema $ :: 'Dynamic
+      :ns $ %{} 'NsEntry (:doc |)
         :code $ quote
           ns calcit.std.util $ :require
             calcit.std.$meta :refer $ calcit-dirname

--- a/deps.cirru
+++ b/deps.cirru
@@ -1,3 +1,3 @@
 
-{} (:calcit-version |0.12.53)
+{} (:calcit-version |0.13.7)
   :dependencies $ {}

--- a/src/date.rs
+++ b/src/date.rs
@@ -1,9 +1,9 @@
 /// DateTime<FixedOffset> is used to store time internally
 ///
-use std::{collections::HashMap, sync::Arc};
+use std::collections::HashMap;
 
 use chrono::{DateTime, Datelike, Duration, FixedOffset, Local, LocalResult, NaiveDate, TimeZone, Timelike, Weekday};
-use cirru_edn::{Edn, EdnMapView, EdnTag, EdnTupleView};
+use cirru_edn::{Edn, EdnMapView, EdnTag};
 use std::ops::Add;
 
 /// calcit represents DateTime in f64
@@ -13,11 +13,11 @@ pub fn parse_time(args: Vec<Edn>) -> Result<Edn, String> {
   if args.len() == 2 {
     match (&args[0], &args[1]) {
       (Edn::Str(s), Edn::Nil) => match DateTime::parse_from_rfc3339(s) {
-        Ok(time) => Ok(Edn::any_ref(time.fixed_offset())),
+        Ok(time) => Ok(Edn::Number(time.timestamp_millis() as f64)),
         Err(e) => Err(format!("parse-time failed, {e}")),
       },
       (Edn::Str(s), Edn::Str(f)) => match DateTime::parse_from_str(s, f) {
-        Ok(time) => Ok(Edn::any_ref(time.fixed_offset())),
+        Ok(time) => Ok(Edn::Number(time.timestamp_millis() as f64)),
         Err(e) => Err(format!("parse-time failed, {s} {f} {e}")),
       },
       (_, _) => Err(format!("parse-time expected 2 arguments, got: {args:?}")),
@@ -29,7 +29,7 @@ pub fn parse_time(args: Vec<Edn>) -> Result<Edn, String> {
 
 #[unsafe(no_mangle)]
 pub fn now_bang(_args: Vec<Edn>) -> Result<Edn, String> {
-  Ok(Edn::any_ref(Local::now().fixed_offset()))
+  Ok(Edn::Number(Local::now().timestamp_millis() as f64))
 }
 
 /// TODO currently only return self, no offset involved yet
@@ -37,6 +37,7 @@ pub fn now_bang(_args: Vec<Edn>) -> Result<Edn, String> {
 pub fn get_timestamp(args: Vec<Edn>) -> Result<Edn, String> {
   if args.len() == 1 {
     match &args[0] {
+      Edn::Number(n) => Ok(Edn::Number(*n)),
       Edn::AnyRef(r) => {
         let v = r.0.read().unwrap();
         if let Some(time) = v.as_any().downcast_ref::<DateTime<FixedOffset>>() {
@@ -72,7 +73,7 @@ pub fn format_time(args: Vec<Edn>) -> Result<Edn, String> {
           _ => None,
         }
       }
-      Edn::Record(record) if record.tag == EdnTag::new("Date") => {
+      Edn::Struct(record) if record.name.as_ref() == "Date" => {
         let mut found = None;
         for entry in &record.pairs {
           if entry.0 == EdnTag::new("date") {
@@ -125,6 +126,14 @@ pub fn format_time(args: Vec<Edn>) -> Result<Edn, String> {
 pub fn extract_time(args: Vec<Edn>) -> Result<Edn, String> {
   if args.len() == 1 {
     match &args[0] {
+      Edn::Number(n) => {
+        let seconds = (*n / 1000.0) as i64;
+        let nanos = ((*n % 1000.0) * 1_000_000.0) as u32;
+        match FixedOffset::east_opt(0).unwrap().timestamp_opt(seconds, nanos) {
+          LocalResult::Single(time) => extract_time(vec![Edn::any_ref(time)]),
+          _ => Err(format!("extract-time expected timestamp, got: {n}")),
+        }
+      }
       Edn::AnyRef(r) => {
         let v = r.0.read().unwrap();
         if let Some(time) = v.as_any().downcast_ref::<DateTime<FixedOffset>>() {
@@ -169,21 +178,12 @@ pub fn from_ymd(args: Vec<Edn>) -> Result<Edn, String> {
             .and_hms_opt(0, 0, 0)
             .ok_or("from_ymd got none")?,
         ) {
-          LocalResult::None => Ok(Edn::Tuple(EdnTupleView {
-            tag: Arc::new(Edn::tag("none")),
-            extra: vec![],
-            enum_tag: None,
-          })),
-          LocalResult::Single(d) => Ok(Edn::Tuple(EdnTupleView {
-            tag: Arc::new(Edn::tag("single")),
-            extra: vec![Edn::Number(d.timestamp_millis() as f64)],
-            enum_tag: None,
-          })),
-          LocalResult::Ambiguous(d, d2) => Ok(Edn::Tuple(EdnTupleView {
-            tag: Arc::new(Edn::tag("ambiguous")),
-            extra: vec![Edn::Number(d.timestamp_millis() as f64), Edn::Number(d2.timestamp_millis() as f64)],
-            enum_tag: None,
-          })),
+          LocalResult::None => Ok(Edn::enum_value("none", vec![])),
+          LocalResult::Single(d) => Ok(Edn::enum_value("single", vec![Edn::Number(d.timestamp_millis() as f64)])),
+          LocalResult::Ambiguous(d, d2) => Ok(Edn::enum_value(
+            "ambiguous",
+            vec![Edn::Number(d.timestamp_millis() as f64), Edn::Number(d2.timestamp_millis() as f64)],
+          )),
         }
       }
       (a, b, c) => Err(format!("from-ymd expected 2 args, got: {a} {b} {c}")),
@@ -208,30 +208,17 @@ pub fn from_ywd(args: Vec<Edn>) -> Result<Edn, String> {
           5 => Weekday::Fri,
           6 => Weekday::Sat,
           _ => {
-            return Ok(Edn::Tuple(EdnTupleView {
-              tag: Arc::new(Edn::tag("err")),
-              extra: vec![Edn::str(format!("invalid digit for weekday: {d}"))],
-              enum_tag: None,
-            }));
+            return Ok(Edn::enum_value("err", vec![Edn::str(format!("invalid digit for weekday: {d}"))]));
           }
         };
         match NaiveDate::from_isoywd_opt(*y as i32, *w as u32, weekday) {
           Some(time) => match Local.from_local_datetime(&time.and_hms_opt(0, 0, 0).ok_or("hms got none")?) {
-            LocalResult::None => Ok(Edn::Tuple(EdnTupleView {
-              tag: Arc::new(Edn::tag("none")),
-              extra: vec![],
-              enum_tag: None,
-            })),
-            LocalResult::Single(d) => Ok(Edn::Tuple(EdnTupleView {
-              tag: Arc::new(Edn::tag("single")),
-              extra: vec![Edn::Number(d.timestamp_millis() as f64)],
-              enum_tag: None,
-            })),
-            LocalResult::Ambiguous(d, d2) => Ok(Edn::Tuple(EdnTupleView {
-              tag: Arc::new(Edn::tag("single")),
-              extra: vec![Edn::Number(d.timestamp_millis() as f64), Edn::Number(d2.timestamp_millis() as f64)],
-              enum_tag: None,
-            })),
+            LocalResult::None => Ok(Edn::enum_value("none", vec![])),
+            LocalResult::Single(d) => Ok(Edn::enum_value("single", vec![Edn::Number(d.timestamp_millis() as f64)])),
+            LocalResult::Ambiguous(d, d2) => Ok(Edn::enum_value(
+              "single",
+              vec![Edn::Number(d.timestamp_millis() as f64), Edn::Number(d2.timestamp_millis() as f64)],
+            )),
           },
           None => Err(format!("from-ywd got invalid args: {y} {w} {weekday}")),
         }

--- a/src/json.rs
+++ b/src/json.rs
@@ -85,7 +85,7 @@ pub fn edn_to_json(data: &Edn, add_colon: bool) -> Result<Value, String> {
 
       Ok(Value::Object(data))
     }
-    Edn::Record(record) => {
+    Edn::Struct(record) => {
       let mut data = serde_json::Map::new();
       for entry in &record.pairs {
         data.insert(entry.0.to_string(), edn_to_json(&entry.1, add_colon)?);

--- a/src/path.rs
+++ b/src/path.rs
@@ -4,9 +4,7 @@ use std::path::{Path, PathBuf};
 #[unsafe(no_mangle)]
 pub fn join_path(args: Vec<Edn>) -> Result<Edn, String> {
   if args.is_empty() {
-    Err(format!(
-      "join-path expected multiple arguments, got: {args:?}"
-    ))
+    Err(format!("join-path expected multiple arguments, got: {args:?}"))
   } else {
     let mut first = true;
     let mut buf: PathBuf = PathBuf::from("");

--- a/src/process.rs
+++ b/src/process.rs
@@ -1,8 +1,8 @@
-use cirru_edn::{Edn, EdnListView, EdnTupleView};
+use cirru_edn::{Edn, EdnListView};
 use std::io::{BufRead, BufReader, Read};
 use std::process::{Command, Stdio};
-use std::sync::mpsc;
 use std::sync::Arc;
+use std::sync::mpsc;
 use std::thread;
 
 /// Reads one child's pipe without blocking the other pipe. Events are line-based
@@ -93,12 +93,7 @@ pub fn stream_command(
   drop(tx);
   thread::spawn(move || {
     for (name, content) in rx {
-      let tag = Edn::tag(name);
-      let event = Edn::Tuple(EdnTupleView {
-        tag: Arc::new(tag),
-        extra: vec![Edn::Str(content.into())],
-        enum_tag: Some(Arc::new(Edn::tag("ProcessOutput"))),
-      });
+      let event = Edn::typed_enum("ProcessOutput", name, vec![Edn::Str(content.into())]);
       if let Err(e) = handler(vec![event]) {
         eprintln!("stream callback failed: {e}");
         break;

--- a/src/time.rs
+++ b/src/time.rs
@@ -39,11 +39,13 @@ pub fn set_interval(
 ) -> Result<Edn, String> {
   if args.len() == 1 {
     if let Edn::Number(n) = args[0] {
-      let task = spawn(move || loop {
-        if let Err(e) = handler(vec![]) {
-          println!("error for interval: {e}");
+      let task = spawn(move || {
+        loop {
+          if let Err(e) = handler(vec![]) {
+            println!("error for interval: {e}");
+          }
+          sleep(time::Duration::from_millis(n as u64));
         }
-        sleep(time::Duration::from_millis(n as u64));
       });
 
       task.join().expect("timer task");


### PR DESCRIPTION
## Summary
- upgrade Calcit and native Cirru EDN dependencies to the 0.13/0.8 runtime
- migrate native enum/struct APIs and keep Date values as timestamps across the dylib boundary
- adapt Option-based collection and variadic behavior in tests and Date formatting

## Validation
- `cargo fmt --check`
- `cargo clippy -- -D warnings`
- `cargo build --release`
- `cr --check-only`
- `cr`
- `cr --entry stream-process`